### PR TITLE
fix(a339x/model) fix FO map light rotation

### DIFF
--- a/hdw-a339x/src/base/headwindsim-aircraft-a330-900/SimObjects/Airplanes/Headwind_A330neo/systems.cfg
+++ b/hdw-a339x/src/base/headwindsim-aircraft-a330-900/SimObjects/Airplanes/Headwind_A330neo/systems.cfg
@@ -253,7 +253,7 @@ lightdef.152 = Type:4#Index:6#LocalPosition:65.92,4.40,4.2#LocalRotation:90,0,-7
 
 ; F/O CEILING / MAP LT (DONE)
 lightdef.153 = Type:4#Index:3#LocalPosition:67.550,1.825,7.000#LocalRotation:90,0,0#EffectFile:A339X_Cockpit_ReadingLight#PotentiometerIndex:12  							; F/O CEILINIG LT
-lightdef.154 = Type:4#Index:3#LocalPosition:67.550,2.550,6.300#LocalRotation:-70.000,0,90.000#EffectFile:A339X_Cockpit_ReadingLight#PotentiometerIndex:13    				; F/O MAP LT
+lightdef.154 = Type:4#Index:3#LocalPosition:67.550,2.550,6.300#LocalRotation:70.000,180,-90.000#EffectFile:A339X_Cockpit_ReadingLight#PotentiometerIndex:13    				; F/O MAP LT
 
 ; JUMPSEAT READING LT (DONE)
 lightdef.155 = Type:4#Index:5#LocalPosition:66.02,0.96,7.9#LocalRotation:110,90,0#EffectFile:A339X_Cockpit_ReadingLight#PotentiometerIndex:97             					; READING LT R


### PR DESCRIPTION
<!-- Original Pull Request Template made by the fantastic FlyByWire Team for the A32NX <3 -->
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
Fixes the rotation of the FO map light.
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

## Screenshots (if necessary)
![image](https://github.com/user-attachments/assets/9e98a351-8177-46bd-a1bf-e15041432558)

<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos).  -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
jonny_23

## Testing instructions
Check that the map light rotation matches the captain's map light.
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for Testing

Every new commit to this PR will cause a new A330-900neo artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **HEADWIND-A339** download link at the bottom of the page